### PR TITLE
Fix to circle radius

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
 						return new L.Light(latlng, {
 							interactive: false,
 							title: feat.properties.tags['name'],
-							radius: (parseFloat(feat.properties.tags['seamark:light:range'], 10) || 1) * 1000,
+							radius: (parseFloat(feat.properties.tags['seamark:light:range'], 10) || 1) * 1852,
 							sequence: sequence,
 							stroke: false,
 							fillOpacity: 0.9,


### PR DESCRIPTION
The [docs](https://leafletjs.com/reference-1.6.0.html#circle) for `L.circle` say that its `radius` option is expressed in meters.

The [OSM Wiki entry for `seamark::lights`](https://wiki.openstreetmap.org/wiki/Seamarks/Lights) says that the `range` attribute is in nautical miles (not km).

There are 1852 m in a nautical mile, so I think that the circle radius should be obtained by multiplying the `range` by 1852.