### PR TITLE
Improve the query and script to display many missing lighthouses and add a Github action to update the data daily

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          wget -O data-full.json https://www.overpass-api.de/api/interpreter?data=%0A%09%09%09%5Bout%3Ajson%5D%5Btimeout%3A300%5D%3B%0A%09%09%09(%0A%09%09%09%20%20node%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20node%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09)%3B%0A%09%09%09out%20body%3B%0A%09%09%09%3E%3B%0A%09%09%09out%20skel%20qt%3B%0A%09%09
+          wget -O data-full.json "https://www.overpass-api.de/api/interpreter?data=%0A%09%09%09%5Bout%3Ajson%5D%5Btimeout%3A300%5D%3B%0A%09%09%09(%0A%09%09%09%20%20node%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20node%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09)%3B%0A%09%09%09out%20body%3B%0A%09%09%09%3E%3B%0A%09%09%09out%20skel%20qt%3B%0A%09%09"
       - name: Commit the data
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -1,0 +1,24 @@
+name: Update data
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '15 0 * * *'
+jobs:
+  scrape:
+    name: Update data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          wget -O data-full.json https://lz4.overpass-api.de/api/interpreter\?data\=%0A%09%09%09%5Bout%3Ajson%5D%5Btimeout%3A200%5D%3B%0A%09%09%09%2F%2F%20gather%20results%0A%09%09%09\(%0A%09%09%09%20%20%2F%2F%20query%20part%20for%3A%20%E2%80%9C%22seamark%3Alight%3Asequence%22%3D\*%E2%80%9D%0A%09%09%09%20%20node%5B%22seamark%3Alight%3Asequence%22%5D\(-90%2C-180%2C90%2C180\)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3Asequence%22%5D\(-90%2C-180%2C90%2C180\)%3B%0A%09%09%09\)%3B%0A%09%09%09%2F%2F%20print%20results%0A%09%09%09out%20body%3B%0A%09%09%09%3E%3B%0A%09%09%09out%20skel%20qt%3B%0A%09%09
+      - name: Commit the data
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 5
+          command: |
+            git config --global user.name 'Pierre Mesure (Github Actions)'
+            git config --global user.email 'pierre@mesu.re'
+            git add data-full.json
+            git commit -am "Updating the data"
+            git push

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          wget -O data-full.json https://lz4.overpass-api.de/api/interpreter\?data\=%0A%09%09%09%5Bout%3Ajson%5D%5Btimeout%3A200%5D%3B%0A%09%09%09%2F%2F%20gather%20results%0A%09%09%09\(%0A%09%09%09%20%20%2F%2F%20query%20part%20for%3A%20%E2%80%9C%22seamark%3Alight%3Asequence%22%3D\*%E2%80%9D%0A%09%09%09%20%20node%5B%22seamark%3Alight%3Asequence%22%5D\(-90%2C-180%2C90%2C180\)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3Asequence%22%5D\(-90%2C-180%2C90%2C180\)%3B%0A%09%09%09\)%3B%0A%09%09%09%2F%2F%20print%20results%0A%09%09%09out%20body%3B%0A%09%09%09%3E%3B%0A%09%09%09out%20skel%20qt%3B%0A%09%09
+          wget -O data-full.json https://www.overpass-api.de/api/interpreter?data=%0A%09%09%09%5Bout%3Ajson%5D%5Btimeout%3A300%5D%3B%0A%09%09%09(%0A%09%09%09%20%20node%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20node%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09%20%20way%5B%22seamark%3Alight%3A1%3Asequence%22%5D(-90%2C-180%2C90%2C180)%3B%0A%09%09%09)%3B%0A%09%09%09out%20body%3B%0A%09%09%09%3E%3B%0A%09%09%09out%20skel%20qt%3B%0A%09%09
       - name: Commit the data
         uses: nick-invision/retry@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# THIS IS A FORK
+
+I did not create this code, the original source is [here](https://github.com/geodienst/lighthousemap) and the map [here](https://geodienst.github.io/lighthousemap/).
+
+Like many others, I learnt about this beautiful gem of data visualisation thanks to this [viral tweet](https://twitter.com/emollick/status/1485467613190832130). I love it! This is such a great example of what can be accomplished with OpenStreetMap and crowdsourced data!
+
+But I was equally disappointed as many others to see that the data hadn't been updated in 3 years.
+
+So I dug in the code and found the Overpass query to fetch up-to-date data. And while I was at it, I added a Github Action to keep it updated. It runs every day at 00:15 CET for now, and I might make it update less often later to use even less energy.
 # Beacon map
 This map shows all the blinking beacons from [OpenStreetMap](https://www.openstreetmap.org/).
 
@@ -14,4 +23,4 @@ The `leaflet.indexedfeaturelayer.js` file contains an extension on Leaflet's Geo
 `leaflet.light.js` contains my best guess on how a light sequence will look based on [these descriptions](https://wiki.openstreetmap.org/wiki/Seamarks/Light_Characters). However, it might be inaccurate, and it tries to do its best with the sometimes not entirely consistent data from OSM.
 
 ## Credits
-This map is made by the [Geodienst](https://www.geodienst.xyz) because it was a fun idea we wanted to try out. Feel free to fork this map and make your own visualisation of OSM data, or contribute improvements back to us. 
+This map is made by the [Geodienst](https://www.geodienst.xyz) because it was a fun idea we wanted to try out. Feel free to fork this map and make your own visualisation of OSM data, or contribute improvements back to us.

--- a/index.html
+++ b/index.html
@@ -19,14 +19,14 @@
 				width: 100%;
 				height: 100%;
 			}
-			
+
 			#controls {
 				position: fixed;
 				bottom: 0;
 				left: 0;
 				z-index: 1000;
 			}
-			
+
 			#seamap .leaflet-control-attribution,
 			#controls {
 				margin: 10px;
@@ -35,7 +35,7 @@
 				background: none;
 				text-shadow: 0px 0px 2px black;
 			}
-			
+
 			#seamap .leaflet-control-attribution a {
 				color: inherit;
 				text-decoration: underline;
@@ -52,13 +52,15 @@
 		</div>
 		<a href="https://github.com/geodienst/lighthousemap"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 1000" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
 		<script id="seamap-query" type="text/x-overpass">
-			[out:json][timeout:25];
+			[out:json][timeout:300];
 			// gather results
 			(
 			  // query part for: “"seamark:light:sequence"=*”
 			  node["seamark:light:sequence"]({{bbox}});
+			  node["seamark:light:1:sequence"]({{bbox}});
 			  way["seamark:light:sequence"]({{bbox}});
-			  relation["seamark:light:sequence"]({{bbox}});
+			  way["seamark:light:1:sequence"]({{bbox}});
+			  // relation["seamark:light:sequence"]({{bbox}});
 			);
 			// print results
 			out body;
@@ -67,7 +69,7 @@
 		</script>
 		<script id="seamap-wikidata-query" type="text/x-sparql">
 			SELECT ?item ?itemLabel ?location ?height ?focalHeight ?sequence
-			WHERE 
+			WHERE
 			{
 			  ?item wdt:P31 wd:Q39715.
 			  ?item wdt:P625 ?location.
@@ -95,7 +97,7 @@
 					position: 'bottomright',
 					prefix: 'Made by <a href="https://www.geodienst.xyz/">Geodienst</a>'
 				}));
-			
+
 			L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png', {
 				detectRetina: true,
 				attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
@@ -118,7 +120,6 @@
 			// let query = document.getElementById('seamap-query').textContent
 			// 	.replace(/\{\{bbox\}\}/g, bounds.join(','));
 
-			
 
 			let url = 'https://www.overpass-api.de/api/interpreter?data=' + encodeURIComponent(query);
 
@@ -165,11 +166,11 @@
 					}
 				}).addTo(map).addData(geojson);
 			});
-			
+
 			let useRealColors = true;
 
 			document.querySelector('input[name=real-colors]').checked = useRealColors;
-			
+
 			document.querySelector('input[name=real-colors]').addEventListener('change', function(e) {
 				useRealColors = this.checked;
 			});
@@ -184,7 +185,7 @@
 						} catch(e){
 							// console.error(e)
 						}
-						
+
 					});
 				};
 

--- a/leaflet.light.js
+++ b/leaflet.light.js
@@ -8,12 +8,36 @@ L.Light = L.Circle.extend({
 });
 
 L.Light.sequence = function(tags, fallbackColor = '#FF0') {
+	renameProperty = function(tags, property) {
+		console.log('test')
+		old_key = 'seamark:light:1:' + property
+		new_key = 'seamark:light:' + property
+
+		if (!(new_key in tags) && old_key in tags) {
+			tags[new_key] = tags[old_key]
+		}
+
+		return tags
+	}
+
+	tags = renameProperty(tags, 'character')
+	tags = renameProperty(tags, 'colour')
+	tags = renameProperty(tags, 'group')
+	tags = renameProperty(tags, 'height')
+	tags = renameProperty(tags, 'period')
+	tags = renameProperty(tags, 'range')
+	tags = renameProperty(tags, 'sector_end')
+	tags = renameProperty(tags, 'sector_start')
+	tags = renameProperty(tags, 'sequence')
+
+
+
 	let character = tags['seamark:light:character'] || 'Fl';
-	
+
 	let colors = (tags['seamark:light:colour'] || fallbackColor).split(';');
 
 	let sequence = tags['seamark:light:sequence'];
-	
+
 	if (character.match(/^Al\./)) {// Alternating color!
 		character = tags['seamark:light:character'].substring(3);
 
@@ -49,7 +73,7 @@ L.Light.sequence = function(tags, fallbackColor = '#FF0') {
 		const flash = 0.2;
 		const longflash = 1.0;
 		const remainder = period - (short * 2 * flash + longflash)
-		
+
 		if (remainder < 0)
 			throw 'Could not convert Q+LFL to Fl: negative remainder';
 
@@ -103,7 +127,7 @@ L.Light.sequence = function(tags, fallbackColor = '#FF0') {
 				console.warn('There are fewer sequences than colors', {character, sequence, colors}, tags);
 
 			return new L.Light.CombinedSequence(sequences);
-	 
+
 	 	default:
 			throw 'Unknown character: ' + character
 	}


### PR DESCRIPTION
I discovered your brilliant project through [this tweet](https://twitter.com/emollick/status/1485467613190832130) yesterday evening and I spent a few hours trying to display missing lighthouses on the map!

This PR does 3 things:
- Add a Github Action that fetches the data every 24h
- Updates the data and includes objects with several lights, i.e. lighthouses with the `seamark:light:1:` and no `seamark:light:`
- Rename the properties of these objects so they can be processed by the script and displayed on the map

It turns out most lighthouses have several lights and they weren't even fetched from OpenStreetMap. This PR fixes that, albeit in a basic way since these new additions are only blinking as their first light is, the other lights are not taken into account.

Have a look at the result [here](https://pierremesure.github.io/lighthousemap/) and see if you can find the lighthouse that you couldn't find on the original map!